### PR TITLE
allow dt2w on other roms

### DIFF
--- a/drivers/input/touchscreen/Kconfig
+++ b/drivers/input/touchscreen/Kconfig
@@ -1307,6 +1307,15 @@ config TOUCHSCREEN_RAYDIUM_CHIPSET
 
 	  If unsure, say N.
 
+config TOUCHSCREEN_COMMON
+	bool "Common touchscreen interface to interact with userspace"
+	default y
+	help
+	  Say Y here if you want to control touchpanel features via
+	  /sys/touchpanel.
+
+	  If unsure, say N.
+
 source "drivers/input/touchscreen/focaltech_touch/Kconfig"
 
 endif

--- a/drivers/input/touchscreen/Makefile
+++ b/drivers/input/touchscreen/Makefile
@@ -119,3 +119,4 @@ obj-$(CONFIG_TOUCHSCREEN_RASPBERRYPI_FW)	+= raspberrypi-ts.o
 obj-$(CONFIG_TOUCHSCREEN_IQS5XX)	+= iqs5xx.o
 obj-$(CONFIG_TOUCHSCREEN_ST)	+= st/
 obj-$(CONFIG_TOUCHSCREEN_FTS)	+= focaltech_touch/
+obj-$(CONFIG_TOUCHSCREEN_COMMON)	+= tp_common.o

--- a/drivers/input/touchscreen/ft3418_i2c/focaltech_gesture.c
+++ b/drivers/input/touchscreen/ft3418_i2c/focaltech_gesture.c
@@ -34,6 +34,9 @@
 * 1.Included header files
 *****************************************************************************/
 #include "focaltech_core.h"
+#ifdef CONFIG_TOUCHSCREEN_COMMON
+#include <linux/input/tp_common.h>
+#endif
 
 /******************************************************************************
 * Private constant and macro definitions using #define
@@ -102,6 +105,35 @@ static struct fts_gesture_st fts_gesture_data;
 /*****************************************************************************
 * Static function prototypes
 *****************************************************************************/
+#ifdef CONFIG_TOUCHSCREEN_COMMON
+static ssize_t double_tap_show(struct kobject *kobj,
+                               struct kobj_attribute *attr, char *buf)
+{
+    struct fts_ts_data *ts_data = fts_data;
+    return sprintf(buf, "%d\n", ts_data->gesture_mode);
+}
+
+static ssize_t double_tap_store(struct kobject *kobj,
+                                struct kobj_attribute *attr, const char *buf,
+                                size_t count)
+{
+    int rc, val;
+    struct fts_ts_data *ts_data = fts_data;
+
+    rc = kstrtoint(buf, 10, &val);
+    if (rc)
+    return -EINVAL;
+
+    ts_data->gesture_mode = !!val;
+    return count;
+}
+
+static struct tp_common_ops double_tap_ops = {
+    .show = double_tap_show,
+    .store = double_tap_store
+};
+#endif
+
 static ssize_t fts_gesture_show(
     struct device *dev, struct device_attribute *attr, char *buf)
 {
@@ -437,6 +469,9 @@ int fts_gesture_switch(struct input_dev *dev, unsigned int type, unsigned int co
 int fts_gesture_init(struct fts_ts_data *ts_data)
 {
     struct input_dev *input_dev = ts_data->input_dev;
+#ifdef CONFIG_TOUCHSCREEN_COMMON
+	int ret;
+#endif
 
     FTS_FUNC_ENTER();
 
@@ -478,6 +513,14 @@ int fts_gesture_init(struct fts_ts_data *ts_data)
     __set_bit(KEY_GESTURE_Z, input_dev->keybit);
 
     fts_create_gesture_sysfs(ts_data->dev);
+
+#ifdef CONFIG_TOUCHSCREEN_COMMON
+    ret = tp_common_set_double_tap_ops(&double_tap_ops);
+    if (ret < 0) {
+        FTS_ERROR("%s: Failed to create double_tap node err=%d\n",
+                  __func__, ret);
+    }
+#endif
 
     memset(&fts_gesture_data, 0, sizeof(struct fts_gesture_st));
     ts_data->gesture_mode = FTS_GESTURE_EN;

--- a/drivers/input/touchscreen/tp_common.c
+++ b/drivers/input/touchscreen/tp_common.c
@@ -1,0 +1,29 @@
+#include <linux/input/tp_common.h>
+
+bool capacitive_keys_enabled;
+struct kobject *touchpanel_kobj;
+
+#define TS_ENABLE_FOPS(type)                                                   \
+	int tp_common_set_##type##_ops(struct tp_common_ops *ops)              \
+	{                                                                      \
+		static struct kobj_attribute kattr =                           \
+			__ATTR(type, (S_IWUSR | S_IRUGO), NULL, NULL);         \
+		kattr.show = ops->show;                                        \
+		kattr.store = ops->store;                                      \
+		return sysfs_create_file(touchpanel_kobj, &kattr.attr);        \
+	}
+
+TS_ENABLE_FOPS(capacitive_keys)
+TS_ENABLE_FOPS(double_tap)
+TS_ENABLE_FOPS(reversed_keys)
+
+static int __init tp_common_init(void)
+{
+	touchpanel_kobj = kobject_create_and_add("touchpanel", NULL);
+	if (!touchpanel_kobj)
+		return -ENOMEM;
+
+	return 0;
+}
+
+core_initcall(tp_common_init);

--- a/include/linux/input/tp_common.h
+++ b/include/linux/input/tp_common.h
@@ -1,0 +1,15 @@
+#include <linux/kobject.h>
+
+extern bool capacitive_keys_enabled;
+extern struct kobject *touchpanel_kobj;
+
+struct tp_common_ops {
+	ssize_t (*show)(struct kobject *kobj, struct kobj_attribute *attr,
+			char *buf);
+	ssize_t (*store)(struct kobject *kobj, struct kobj_attribute *attr,
+			 const char *buf, size_t count);
+};
+
+int tp_common_set_capacitive_keys_ops(struct tp_common_ops *ops);
+int tp_common_set_double_tap_ops(struct tp_common_ops *ops);
+int tp_common_set_reversed_keys_ops(struct tp_common_ops *ops);


### PR DESCRIPTION
this kernel only supports default xiaomi's dt2w
support aosp one so other roms can use it!
fix #3 

